### PR TITLE
Fix: Parse payload to json before adding it

### DIFF
--- a/util/fcm.js
+++ b/util/fcm.js
@@ -23,7 +23,12 @@ module.exports = {
         }
 
         if (entry.payload) {
-            payload = { ...payload, ...entry.payload };
+          try {
+            let jsonPayload = JSON.parse(entry.payload);
+            payload = { ...payload, ...jsonPayload };
+          } catch {
+            console.log("parsing failed so sending without payload")
+          }
         }
 
         let options = {


### PR DESCRIPTION
When adding a payload to the push notification it tries to add the payload as a string instead of a json object. This causes an error and it doesn't send the notification at all. 

I added a step that parses the json and if it succeeds it adds the json to the payload. If it fails it will continue with sending the notification. This fixes my issue and with this fix i can add payloads to the notifications.

@itisnajim Please let me know if you think this is a good solution or if you have a better solution for this.