### PR TITLE
Fix error on server start when config doesn't exist yet

### DIFF
--- a/util/fcm.js
+++ b/util/fcm.js
@@ -64,12 +64,12 @@ module.exports = {
     * */
     initialize: async (strapi) => {
         // console.log('initialize FCM');
-        const { serviceAccount } = await strapi.db.query('plugin::strapi-plugin-fcm.fcm-plugin-configuration').findOne({
+        const data = await strapi.db.query('plugin::strapi-plugin-fcm.fcm-plugin-configuration').findOne({
             select: ['serviceAccount']
         });
         // console.log('serviceAccount', serviceAccount);
         // console.log('admin.apps?.length', admin.apps?.length);
-        if (serviceAccount) {
+        if (data !== null && data.serviceAccount) {
             if (admin.apps?.length > 1) {
                 Promise.all(admin.apps.map(app => app.delete())).then(() => {
                     admin.initializeApp({

--- a/util/fcm.js
+++ b/util/fcm.js
@@ -73,12 +73,12 @@ module.exports = {
             if (admin.apps?.length > 1) {
                 Promise.all(admin.apps.map(app => app.delete())).then(() => {
                     admin.initializeApp({
-                        credential: admin.credential.cert(serviceAccount)
+                        credential: admin.credential.cert(data.serviceAccount)
                     });
                 });
             } else {
                 admin.initializeApp({
-                    credential: admin.credential.cert(serviceAccount),
+                    credential: admin.credential.cert(data.serviceAccount),
                 });
             }
         }


### PR DESCRIPTION
 The purpose of this pull request is to fix this error which occurs on the server start 

TypeError: Cannot destructure property 'serviceAccount' of '(intermediate value)' as it is null.
 at Object.initialize (node_modules/strapi-plugin-fcm/util/fcm.js:67:17)