### PR TITLE
Payload is already in Json and not a string

### DIFF
--- a/util/fcm.js
+++ b/util/fcm.js
@@ -23,12 +23,7 @@ module.exports = {
         }
 
         if (entry.payload) {
-          try {
-            let jsonPayload = JSON.parse(entry.payload);
-            payload = { ...payload, ...jsonPayload };
-          } catch {
-            console.log("parsing failed so sending without payload")
-          }
+            payload = { ...payload, ...entry.payload };
         }
 
         let options = {


### PR DESCRIPTION
We don't need to parse it because it's already stored in JSON