### PR TITLE
Fixed: Could not load js config file.

### DIFF
--- a/server/services/fcm-notification.js
+++ b/server/services/fcm-notification.js
@@ -13,9 +13,9 @@ const {
     convertPagedToStartLimit,
     shouldCount,
     transformPaginationResponse,
-} = require('@strapi/strapi/lib/core-api/service/pagination');
+} = require('@strapi/strapi');
 
-const { getFetchParams } = require('@strapi/strapi/lib/core-api/service');
+const { getFetchParams } = require('@strapi/strapi');
 
 const {
     hasDraftAndPublish,

--- a/server/services/fcm-plugin-configuration.js
+++ b/server/services/fcm-plugin-configuration.js
@@ -13,9 +13,9 @@ const {
     convertPagedToStartLimit,
     shouldCount,
     transformPaginationResponse,
-} = require('@strapi/strapi/lib/core-api/service/pagination');
+} = require('@strapi/strapi');
 
-const { getFetchParams } = require('@strapi/strapi/lib/core-api/service');
+const { getFetchParams } = require('@strapi/strapi');
 
 const {
     hasDraftAndPublish,

--- a/server/services/fcm-target.js
+++ b/server/services/fcm-target.js
@@ -5,9 +5,9 @@ const {
     convertPagedToStartLimit,
     shouldCount,
     transformPaginationResponse,
-} = require('@strapi/strapi/lib/core-api/service/pagination');
+} = require('@strapi/strapi');
 
-const { getFetchParams } = require('@strapi/strapi/lib/core-api/service');
+const { getFetchParams } = require('@strapi/strapi');
 
 
 // we will use this for now, until we have a better way.

--- a/server/services/fcm-topic.js
+++ b/server/services/fcm-topic.js
@@ -7,9 +7,9 @@ const {
     convertPagedToStartLimit,
     shouldCount,
     transformPaginationResponse,
-} = require('@strapi/strapi/lib/core-api/service/pagination');
+} = require('@strapi/strapi');
 
-const { getFetchParams } = require('@strapi/strapi/lib/core-api/service');
+const { getFetchParams } = require('@strapi/strapi');
 
 const {
     hasDraftAndPublish,


### PR DESCRIPTION
Is ready to work!

The way the package was required was obsolete with the new version of strapi.
Fixed with: require:(@strapi/strapi)